### PR TITLE
feat: remove Node.js v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 12
   - 10
-  - 8
 before_install:
   - npm install -g npm
   - npm --version

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "directories": {
     "test": "test"
   },
+  "engines": {
+    "node": "10 || >=12"
+  },
   "scripts": {
     "lint": "eslint *.js test/*.js",
     "pretest": "npm run lint",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum supported version of
Node.js.